### PR TITLE
Fix user account creation

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -100,7 +100,7 @@ EOF
   ##
   # USER ACCOUNTS
   ##
-  echo "$(env | grep '^ACCOUNT_')" | while IFS= read -r I_ACCOUNT ; do
+  echo "$(env | grep '^ACCOUNT_')" | while read -r I_ACCOUNT ; do
     ACCOUNT_NAME=$(echo "$I_ACCOUNT" | cut -d'=' -f1 | sed 's/ACCOUNT_//g' | tr '[:upper:]' '[:lower:]')
     ACCOUNT_PASSWORD=$(echo "$I_ACCOUNT" | sed 's/^[^=]*=//g')
 


### PR DESCRIPTION
There seems to be an issue caused by `IFS=` in the account creation loop:

```
docker run -ti --rm -e ACCOUNT_a=KA5qrjut -e ACCOUNT_b=PvLYHv6b knapoc/samba:alpine /bin/true

Welcome to the servercontainers/samba

>> CONTAINER: starting initialisation
>> SAMBA CONFIG: no $SAMBA_CONF_WORKGROUP set, using 'WORKGROUP'
>> SAMBA CONFIG: no $SAMBA_CONF_SERVER_STRING set, using 'file server'
>> SAMBA CONFIG: no $SAMBA_CONF_MAP_TO_GUEST set, using 'Bad User'
>> ACCOUNT: adding account: a
Changing password for a
New password:
Bad password: similar to username
Retype password:
passwd: password for a is unchanged
Changing password for a
New password:
Bad password: similar to username
Retype password:
passwd: password for a changed by root
New SMB password:
Retype new SMB password:
Added user a.
Enabled user a.
>> CMD: exec docker CMD
/bin/true
```

Note how it iterates over the same user multiple times. Not sure what the `$IFS`
override really does there as `read` reads per line anyways, but removing seems
to fix the problem:

```
docker run -ti --rm -e ACCOUNT_a=KA5qrjut -e ACCOUNT_b=PvLYHv6b samba-fixed /bin/true

Welcome to the servercontainers/samba

>> CONTAINER: starting initialisation
>> SAMBA CONFIG: no $SAMBA_CONF_WORKGROUP set, using 'WORKGROUP'
>> SAMBA CONFIG: no $SAMBA_CONF_SERVER_STRING set, using 'file server'
>> SAMBA CONFIG: no $SAMBA_CONF_MAP_TO_GUEST set, using 'Bad User'
>> ACCOUNT: adding account: a
Enter new UNIX password: Retype new UNIX password: passwd: password updated successfully
New SMB password:
Retype new SMB password:
Added user a.
Enabled user a.
>> ACCOUNT: adding account: b
Enter new UNIX password: Retype new UNIX password: passwd: password updated successfully
New SMB password:
Retype new SMB password:
Added user b.
Enabled user b.
>> CMD: exec docker CMD
/bin/true

```

(`samba-fixed` in the above command is locally built image with the fix applied)